### PR TITLE
fix comment.vue import

### DIFF
--- a/resources/assets/js/components/Comments.vue
+++ b/resources/assets/js/components/Comments.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script>
-import Comment from './comment.vue';
+import Comment from './Comment.vue';
 import commentServices from '../services/CommentServices';
 
 export default {


### PR DESCRIPTION
Fix error:

Browserify Failed!: Cannot find module './comment.vue' from '/var/www/html/superlearn/resources/assets/js/components'